### PR TITLE
Fixes parsing of link to små partier XLS(X) when they're sometimes formatted in another way

### DIFF
--- a/sma-partier/systemet.py
+++ b/sma-partier/systemet.py
@@ -16,7 +16,7 @@ release_dates = ['19 jan', '2 feb', '16 feb', '2 mars', '16 mars', '6 april', '2
 
 systemet_request = requests.get(systembolaget)
 
-result = re.findall('<a href=\"\/imagelibrary\/publishedmedia\/[\w]+\/Sm-_partier_[\w]+.xlsx\">[\w\s]+<\/a>', systemet_request.text)
+result = re.findall('<a href=\"\/imagelibrary\/publishedmedia\/[\w]+\/Sm-_partier_[\w]+(?:[.]xls)?.xlsx\">[\w\s]+<\/a>', systemet_request.text)
 for line in result:
     after = line.split('"')[1]
     file_name = after.split('/')[-1]


### PR DESCRIPTION
Latest .xlsx file had the ending `.xls.xlsx` instead of just `.xlsx`.
```
<a href="/imagelibrary/publishedmedia/wfxnv92vojvk5wndngkz/Sm-_partier_6_april.xls.xlsx">små partier 6 april</a>
```

Changed the regex to also account for that edge-case so that all of the below would match.

```
<a href="/imagelibrary/publishedmedia/901k3r5r0vvjy7lgdo27/Sm-_partier_19_januari.xlsx">små partier 19 jan</a>
<a href="/imagelibrary/publishedmedia/0y4xqtn0c45ljwvqvwws/Sm-_partier_2_februari.xlsx">små partier 2 feb</a>
<a href="/imagelibrary/publishedmedia/achqfjw15xjiyf26ac5h/Sm-_partier_16_februari.xlsx">små partier 16 feb</a>
<a href="/imagelibrary/publishedmedia/eiu1w911kukbg3ye0vsk/Sm-_partier_2_mars.xlsx">små partier 2 mars</a>
<a href="/imagelibrary/publishedmedia/wmp4zg3q4qtnkdvto5y7/Sm-_partier_16_mars.xlsx">små partier 16 mars</a>
<a href="/imagelibrary/publishedmedia/wfxnv92vojvk5wndngkz/Sm-_partier_6_april.xls.xlsx">små partier 6 april</a>
```
